### PR TITLE
MRA Fixes

### DIFF
--- a/releases/Cosmic Alien.mra
+++ b/releases/Cosmic Alien.mra
@@ -6,11 +6,11 @@
 	<manufacturer>Universal</manufacturer>
 	<category>Space</category>
 	<rbf>cosmic</rbf>
-	<buttons names="Fire,Start 1P,Start 2P,Coin" default="A,Start,Select,R"/>
+	<buttons names="Fire,-,Start 1P,Start 2P,Coin" default="A,Start,Select,R"/>
 	<switches default="00,00,00">
 		<dip bits="0"     	name="Cabinet"     ids="Upright,Cocktail"/>
 		<dip bits="1"   	name="Lives"       ids="5,3"/>
-		<dip bits="2,3"		name="Coinage"	   ids="1C-1C,1C-2C,2C-1C"/>
+		<dip bits="2,3"		name="Coinage"	   ids="1 Coin 1 Credit,1 Coin 2 Credits,2 Coins 1 Credit"/>
 		<dip bits="4,5"   	name="Bonus life"  ids="None,15000,10000,5000"/>
 		<dip bits="16"    	name="Screen flip" ids="Off,On"/>
 	</switches>

--- a/releases/Magical Spot.mra
+++ b/releases/Magical Spot.mra
@@ -6,12 +6,12 @@
 	<manufacturer>Universal</manufacturer>
 	<category>Garden</category>
 	<rbf>cosmic</rbf>
-	<buttons names="Fire,Start 1P,Start 2P,Coin" default="A,Start,Select,R"/>
+	<buttons names="Fire,-,Start 1P,Start 2P,Coin" default="A,Start,Select,R"/>
 	<switches default="00,0F,00">
 		<dip bits="0,1"   	name="Bonus life"  ids="None,2000,3000,4000"/>
 		<dip bits="3,4"   	name="Lives"       ids="2,3,4,5"/>
                 <dip bits="5"     	name="Cabinet"     ids="Upright,Cocktail"/>
-		<dip bits="8,11"	name="Coinage"	   ids="4C-4C,4C-3C,4C-2C,4C-1C,3C-4C,3C-3C,3C-2C,3C-1C,2C-3C,2C-2C,2C-1C,1C-5C,1C-4C,1C-3C,1C-2C,1C-1C"/>
+		<dip bits="8,11"	name="Coinage"	   ids="4 Coins 4 Credits,4 Coins 3 Credits,4 Coins 2 Credits,4 Coins 1 Credit,3 Coins 4 Credits,3 Coins 3 Credits,3 Coins 2 Credits,3 Coins 1 Credit,2 Coins 3 Credits,2 Coins 2 Credits,2 Coins 1 Credit,1 Coin 5 Credits,1 Coin 4 Credits,1 Coin 3 Credits,1 Coin 2 Credits,1 Coin 1 Credit"/>
 		<dip bits="16"    	name="Screen flip" ids="Off,On"/>
 	</switches>
 	<rom index="1">

--- a/releases/Space Panic.mra
+++ b/releases/Space Panic.mra
@@ -8,7 +8,7 @@
 	<rbf>cosmic</rbf>
 	<buttons names="Dig,Fill,Start 1P,Start 2P,Coin" default="A,B,Start,Select,R"/>
 	<switches default="00,00,00">
-		<dip bits="0,1,2" name="Coinage"     ids="1C-1C,1C-2C,1C-3C,1C-4C,2C-3C,NA,NA"/>
+		<dip bits="0,2"   name="Coinage"     ids="1 Coin 1 Credit, 1 Coin 2 Credits, 1 Coin 3 Credits, 1 Coin 4 Credits, 1 Coin 5 Credits, 2 Coins 3 Credits"/>
 		<dip bits="3"     name="Cabinet"     ids="Upright,Cocktail"/>
 		<dip bits="4"     name="Bonus life"  ids="3000,5000"/>
                 <dip bits="5"     name="Lives"       ids="3,4"/>


### PR DESCRIPTION
This commit fixes two problems in the MRA. First, in Magical Spot and
Cosmic Alien, the buttons definition didn't skip the unused second
game button, so the subsequent definitions were off (in particular,
there was no way to operate the coin). Second, in Space Panic,
the bits for coinage were specified incorrectly (0,1,2 vs 0,2).
Finally, also expanded the 1C_1C abbreviations out (and added the
missing 1 Coin 5 Credits setting to Space Panic.